### PR TITLE
#5 のリファクタリング + ShogiMock.scalaの実装

### DIFF
--- a/src/main/scala/core/Area.scala
+++ b/src/main/scala/core/Area.scala
@@ -1,22 +1,5 @@
 package core
 
-sealed trait Location
-
-/**
-  *  しょうぎばんのマスを表す
-  * @param area マスの座標を表す
-  * @param maybeKoma マスに乗っている駒、または何も乗っていないことを表す
-  */
-case class Masu[A <: Area](area: A, maybeKoma: Option[Koma]) extends Location {
-  val x = area.x
-  val y = area.y
-}
-
-/**
-  * 駒台を表す
-  */
-case class Komadai[P <: Player](player: P, komas: Seq[Koma]) extends Location
-
 /**
   * マスの座標を表す
   * @param x マスのx座標を表す。1~3がA~Cを表す

--- a/src/main/scala/core/Board.scala
+++ b/src/main/scala/core/Board.scala
@@ -23,36 +23,9 @@ case class Board(
     senteKomadai: Komadai[Sente.type],
     goteKomadai: Komadai[Gote.type]
 ) {
-  val actualKomas: Seq[Koma] = Seq(
-    a1.maybeKoma,
-    a2.maybeKoma,
-    a3.maybeKoma,
-    a4.maybeKoma,
-    b1.maybeKoma,
-    b2.maybeKoma,
-    b3.maybeKoma,
-    b4.maybeKoma,
-    c1.maybeKoma,
-    c2.maybeKoma,
-    c3.maybeKoma,
-    c4.maybeKoma
-  ).flatten ++ senteKomadai.komas ++ goteKomadai.komas
 
-  assert(
-    actualKomas.collect { case lion: Lion     => lion }.length == 2 &&
-      actualKomas.collect { case kirin: Kirin => kirin }.length == 2 &&
-      actualKomas.collect { case zou: Zou     => zou }.length == 2 &&
-      (
-        (actualKomas.collect { case hiyoko: Hiyoko       => hiyoko }.length == 2 &&
-          actualKomas.collect { case niwatori: Niwatori => niwatori }.length == 0) ||
-          (
-            actualKomas.collect { case hiyoko: Hiyoko       => hiyoko }.length == 0 &&
-            actualKomas.collect { case niwatori: Niwatori => niwatori }.length == 2
-          ) ||
-          (actualKomas.collect { case hiyoko: Hiyoko      => hiyoko }.length == 1 &&
-            actualKomas.collect { case niwatori: Niwatori => niwatori }.length == 1)
-      )
-  )
+  Board.validateKomaCount(this)
+
 }
 object Board {
   def factory: Board = Board(
@@ -71,4 +44,32 @@ object Board {
     senteKomadai = Komadai(Sente, Seq.empty),
     goteKomadai = Komadai(Gote, Seq.empty)
   )
+
+  private def validateKomaCount(board: Board): Unit = {
+    val komas: Seq[Koma] = Seq(
+      board.a1.maybeKoma,
+      board.a2.maybeKoma,
+      board.a3.maybeKoma,
+      board.a4.maybeKoma,
+      board.b1.maybeKoma,
+      board.b2.maybeKoma,
+      board.b3.maybeKoma,
+      board.b4.maybeKoma,
+      board.c1.maybeKoma,
+      board.c2.maybeKoma,
+      board.c3.maybeKoma,
+      board.c4.maybeKoma
+    ).flatten ++ board.senteKomadai.komas ++ board.goteKomadai.komas
+
+    val lionCount     = komas.collect { case lion: Lion         => lion }.length
+    val kirinCount    = komas.collect { case kirin: Kirin       => kirin }.length
+    val zouCount      = komas.collect { case zou: Zou           => zou }.length
+    val hiyokoCount   = komas.collect { case hiyoko: Hiyoko     => hiyoko }.length
+    val niwatoriCount = komas.collect { case niwatori: Niwatori => niwatori }.length
+
+    assert(lionCount == 2)
+    assert(kirinCount == 2)
+    assert(zouCount == 2)
+    assert(hiyokoCount + niwatoriCount == 2)
+  }
 }

--- a/src/main/scala/core/Komadai.scala
+++ b/src/main/scala/core/Komadai.scala
@@ -1,0 +1,6 @@
+package core
+
+/**
+  * 駒台を表す
+  */
+case class Komadai[P <: Player](player: P, komas: Seq[Koma])

--- a/src/main/scala/core/Masu.scala
+++ b/src/main/scala/core/Masu.scala
@@ -1,0 +1,11 @@
+package core
+
+/**
+  *  しょうぎばんのマスを表す
+  * @param area マスの座標を表す
+  * @param maybeKoma マスに乗っている駒、または何も乗っていないことを表す
+  */
+case class Masu[A <: Area](area: A, maybeKoma: Option[Koma]) {
+  val x = area.x
+  val y = area.y
+}

--- a/src/main/scala/core/Shiai.scala
+++ b/src/main/scala/core/Shiai.scala
@@ -3,18 +3,18 @@ package core
 import core.Board
 
 final case class Shiai(
-    shogiban: Board,
-    shiaiStatus: Shiai.ShiaiStatus
+    board: Board,
+    status: Shiai.Status
 )
 
 object Shiai {
-  sealed trait ShiaiStatus
-  object ShiaiStatus {
-    object Player1 extends ShiaiStatus
-    object Player2 extends ShiaiStatus
-    object Finish  extends ShiaiStatus
+  sealed trait Status
+  object Status {
+    object Player1 extends Status
+    object Player2 extends Status
+    object Finish  extends Status
   }
 
-  def init: Shiai = Shiai(Board.factory, ShiaiStatus.Player1)
+  def init: Shiai = Shiai(Board.factory, Status.Player1)
 
 }

--- a/src/main/scala/web/ShogiMock.scala
+++ b/src/main/scala/web/ShogiMock.scala
@@ -31,60 +31,65 @@ class ShogiMock {
     import core._
     import io.circe._
 
-    val komaEncoder: Encoder[Koma] = Encoder.instance {
-      case Koma.Lion   => Json.fromString("Lion")
-      case Koma.Kirin  => Json.fromString("Kirin")
-      case Koma.Zou    => Json.fromString("Zou")
-      case Koma.Hiyoko => Json.fromString("Hiyoko")
+    val playerEncoder: Encoder[Player] = Encoder.instance {
+      case Sente => Json.fromString("Sente")
+      case Gote  => Json.fromString("Gote")
     }
 
-    val locationEncoder: Encoder[Location] = Encoder.instance {
-      case Location.OnPlayer1Tegoma =>
-        Json.obj(
-          "tpe" -> Json.fromString("onPlayer1Tegoma")
-        )
-      case Location.OnPlayer2Tegoma =>
-        Json.obj(
-          "tpe" -> Json.fromString("onPlayer1Tegoma")
-        )
-      case Location.OnShogiban(yoko, tate) =>
-        Json.obj(
-          "tpe"  -> Json.fromString("onShogiban"),
-          "yoko" -> Json.fromInt(yoko.n),
-          "tate" -> Json.fromInt(tate.n)
-        )
-    }
-
-    val komaStatusEncoder: Encoder[KomaStatus] = Encoder.instance { a =>
+    val komaEncoder: Encoder[Koma] = Encoder.instance { koma =>
+      val tpe = koma match {
+        case Koma.Lion(_)     => "Lion"
+        case Koma.Kirin(_)    => "Kirin"
+        case Koma.Zou(_)      => "Zou"
+        case Koma.Hiyoko(_)   => "Hiyoko"
+        case Koma.Niwatori(_) => "Niwatori"
+      }
       Json.obj(
-        "koma"     -> komaEncoder(a.koma),
-        "loaction" -> locationEncoder(a.location)
+        "tpe"    -> Json.fromString(tpe),
+        "player" -> playerEncoder(koma.player)
       )
     }
 
-    val shogibanEncoder: Encoder[Shogiban] = Encoder.instance { a =>
+    val masuEncoder: Encoder[Masu[_]] = Encoder.instance { masu =>
+      masu.maybeKoma match {
+        case None       => Json.Null
+        case Some(koma) => komaEncoder(koma)
+      }
+    }
+
+    val komadaiEncoder: Encoder[Komadai[_]] = Encoder.instance { komadai =>
+      Json.fromValues(komadai.komas.map(komaEncoder.apply))
+    }
+
+    val boardEncoder: Encoder[Board] = Encoder.instance { board =>
       Json.obj(
-        "lion1"   -> komaStatusEncoder(a.lion1),
-        "lion2"   -> komaStatusEncoder(a.lion2),
-        "kirin1"  -> komaStatusEncoder(a.kirin1),
-        "kirin2"  -> komaStatusEncoder(a.kirin2),
-        "zou1"    -> komaStatusEncoder(a.zou1),
-        "zou2"    -> komaStatusEncoder(a.zou2),
-        "hiyoko1" -> komaStatusEncoder(a.hiyoko1),
-        "hiyoko2" -> komaStatusEncoder(a.hiyoko2)
+        "a1"           -> masuEncoder(board.a1),
+        "a2"           -> masuEncoder(board.a2),
+        "a3"           -> masuEncoder(board.a3),
+        "a4"           -> masuEncoder(board.a4),
+        "b1"           -> masuEncoder(board.b1),
+        "b2"           -> masuEncoder(board.b2),
+        "b3"           -> masuEncoder(board.b3),
+        "b4"           -> masuEncoder(board.b4),
+        "c1"           -> masuEncoder(board.c1),
+        "c2"           -> masuEncoder(board.c2),
+        "c3"           -> masuEncoder(board.c3),
+        "c4"           -> masuEncoder(board.c4),
+        "senteKomadai" -> komadaiEncoder(board.senteKomadai),
+        "goteKomadai"  -> komadaiEncoder(board.goteKomadai)
       )
     }
 
-    val shiaiStatusEncoder: Encoder[Shiai.ShiaiStatus] = Encoder.instance {
-      case Shiai.ShiaiStatus.Player1 => Json.fromString("Player1")
-      case Shiai.ShiaiStatus.Player2 => Json.fromString("Player2")
-      case Shiai.ShiaiStatus.Finish  => Json.fromString("Finish")
+    val statusEncoder: Encoder[Shiai.Status] = Encoder.instance {
+      case Shiai.Status.Player1 => Json.fromString("Player1")
+      case Shiai.Status.Player2 => Json.fromString("Player2")
+      case Shiai.Status.Finish  => Json.fromString("Finish")
     }
 
     val shiaiEncoder: Encoder[Shiai] = Encoder.instance { a =>
       Json.obj(
-        "shogiban"    -> shogibanEncoder(a.shogiban),
-        "shiaiStatus" -> shiaiStatusEncoder(a.shiaiStatus)
+        "board"  -> boardEncoder(a.board),
+        "status" -> statusEncoder(a.status)
       )
     }
 

--- a/src/test/scala/core/BoardSpec.scala
+++ b/src/test/scala/core/BoardSpec.scala
@@ -43,9 +43,23 @@ class BoardSpec extends AnyFlatSpec with Matchers {
         c2 = Masu(C2, None),
         c3 = Masu(C3, None),
         c4 = Masu(C4, Some(Kirin(Sente))),
-        senteKomadai = Komadai(Sente, Seq(Kirin(Sente), Kirin(Sente), Zou(Sente), Zou(Sente), Lion(Sente), Lion(Sente), Hiyoko(Sente), Hiyoko(Sente), Hiyoko(Sente))),
-        goteKomadai = Komadai(Gote, Seq.empty))
-      }
+        senteKomadai = Komadai(
+          Sente,
+          Seq(
+            Kirin(Sente),
+            Kirin(Sente),
+            Zou(Sente),
+            Zou(Sente),
+            Lion(Sente),
+            Lion(Sente),
+            Hiyoko(Sente),
+            Hiyoko(Sente),
+            Hiyoko(Sente)
+          )
+        ),
+        goteKomadai = Komadai(Gote, Seq.empty)
+      )
+    }
   }
 
   it should "実際の駒より少ない駒が存在する盤面はassertionErrorになる" in {
@@ -63,8 +77,12 @@ class BoardSpec extends AnyFlatSpec with Matchers {
         c2 = Masu(C2, None),
         c3 = Masu(C3, None),
         c4 = Masu(C4, Some(Kirin(Sente))),
-        senteKomadai = Komadai(Sente, Seq(Kirin(Sente), Kirin(Sente), Zou(Sente), Zou(Sente), Lion(Sente), Lion(Sente), Hiyoko(Sente))),
-        goteKomadai = Komadai(Gote, Seq.empty))
+        senteKomadai = Komadai(
+          Sente,
+          Seq(Kirin(Sente), Kirin(Sente), Zou(Sente), Zou(Sente), Lion(Sente), Lion(Sente), Hiyoko(Sente))
+        ),
+        goteKomadai = Komadai(Gote, Seq.empty)
+      )
     }
   }
 }


### PR DESCRIPTION
https://github.com/serviver-agent/shogi-api-server/pull/5

```
$ http get :8080/shogi
HTTP/1.1 200 OK
Content-Length: 707
Content-Type: application/json
Date: Mon, 21 Sep 2020 06:43:21 GMT
Server: akka-http/10.2.0

{
    "board": {
        "a1": {
            "player": "Gote",
            "tpe": "Kirin"
        },
        "a2": null,
        "a3": null,
        "a4": {
            "player": "Sente",
            "tpe": "Zou"
        },
        "b1": {
            "player": "Gote",
            "tpe": "Lion"
        },
        "b2": {
            "player": "Gote",
            "tpe": "Hiyoko"
        },
        "b3": {
            "player": "Sente",
            "tpe": "Hiyoko"
        },
        "b4": {
            "player": "Sente",
            "tpe": "Lion"
        },
        "c1": {
            "player": "Gote",
            "tpe": "Zou"
        },
        "c2": null,
        "c3": null,
        "c4": {
            "player": "Sente",
            "tpe": "Kirin"
        },
        "goteKomadai": [],
        "senteKomadai": []
    },
    "status": "Player1"
}
```